### PR TITLE
Unit tests and Attribute bug fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = venv, .git, __pycache__, .ipynb_checkpoints
+ignore = F821,W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pywbgt"
-version     = "2.3.0"
+version     = "2.3.1"
 description = "Package for estimating wetbulb globe temperature using various algorithms"
 readme      = "README.md"
 authors     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pywbgt"
-version     = "2.3.1"
+version     = "2.3.2"
 description = "Package for estimating wetbulb globe temperature using various algorithms"
 readme      = "README.md"
 authors     = [

--- a/src/pywbgt/__init__.py
+++ b/src/pywbgt/__init__.py
@@ -226,7 +226,7 @@ def wbgt(method: str, *args, **kwargs):
         # to the coords object
         val = res.pop(key)
         attrs = {
-            'units': val.units,
+            'units': str(val.units),
             **ATTRS.get(key, {}),
         }
         coords = coords.assign(

--- a/tests/test_bernard.py
+++ b/tests/test_bernard.py
@@ -1,61 +1,62 @@
 import unittest
-from itertools import starmap
 
 import pandas
 import numpy
 from metpy.units import units
 
-from pywbgt import bernard 
+from pywbgt import bernard
 
-def degMinSec2Frac( degree, minute, second ):
 
-  return degree + (minute + second/60.0)/60.0
+def degMinSec2Frac(degree, minute, second):
+
+    return degree + (minute + second / 60.0) / 60.0
+
 
 class TestBernard(unittest.TestCase):
 
-    def setUp( self ):
+    def setUp(self):
 
-        lats = ( 33, 43, 59)
+        lats = (33, 43, 59)
         lons = (-84, 22, 59)
 
-        self.dates   = pandas.date_range(
-            '20000101T16', 
-            '20010101T16', 
-            freq      = 'MS',
-            inclusive = 'left'
+        self.dates = pandas.date_range(
+            start='20000101T16',
+            start='20010101T16',
+            freq='MS',
+            inclusive='left'
         )
 
-        self.solar  = units.Quantity( [500.0,  805.0], 'watt/meter**2')
-        self.pres   = units.Quantity( [985.0, 1013.0], 'hPa')
-        self.Tair   = units.Quantity( [ 25.0,   35.0], 'degree_Celsius')
-        self.Tdew   = units.Quantity( [ 15.0,   25.0], 'degree_Celsius')
-        self.speed  = units.Quantity( [  1.0,    5.0], 'mile/hour')
-        self.zspeed = units.Quantity( 2.0, 'meters' )
-        self.lats   = numpy.full( self.solar.size, degMinSec2Frac(*lats) )
-        self.lons   = numpy.full( self.solar.size, degMinSec2Frac(*lons) )
+        self.solar = units.Quantity([500.0, 805.0], 'watt/meter**2')
+        self.pres = units.Quantity([985.0, 1013.0], 'hPa')
+        self.Tair = units.Quantity([25.0, 35.0], 'degree_Celsius')
+        self.Tdew = units.Quantity([15.0, 25.0], 'degree_Celsius')
+        self.speed = units.Quantity([1.0, 5.0], 'mile/hour')
+        self.zspeed = units.Quantity(2.0, 'meters')
+        self.lats = numpy.full(self.solar.size, degMinSec2Frac(*lats))
+        self.lons = numpy.full(self.solar.size, degMinSec2Frac(*lons))
 
     def compute_wbgt(self):
 
         return bernard.wetbulb_globe(
             self.dates,
-            numpy.resize(self.lats,  self.dates.size),
-            numpy.resize(self.lons,  self.dates.size),
+            numpy.resize(self.lats, self.dates.size),
+            numpy.resize(self.lons, self.dates.size),
             numpy.resize(self.solar, self.dates.size),
-            numpy.resize(self.pres,  self.dates.size),
-            numpy.resize(self.Tair,  self.dates.size),
-            numpy.resize(self.Tdew,  self.dates.size),
+            numpy.resize(self.pres, self.dates.size),
+            numpy.resize(self.Tair, self.dates.size),
+            numpy.resize(self.Tdew, self.dates.size),
             numpy.resize(self.speed, self.dates.size),
-            zspeed = self.zspeed,
-            min_speed = units.Quantity(0, 'm/s'),
+            zspeed=self.zspeed,
+            min_speed=units.Quantity(0, 'm/s'),
         )
 
     def test_conv_heat_flow_coeff(self):
 
         ref_vals = [
-             7.33563906422347, 17.23983369440773,  7.29728047905653,
-            17.23746167679371,  7.30163605847636, 17.23687164492864,
-             7.30178758577696, 17.23666888682254,  7.29826760007174,
-            17.23822295266038,  7.30015437019847, 17.23957011909292,
+            7.33563906422347, 17.23983369440773, 7.29728047905653,
+            17.23746167679371, 7.30163605847636, 17.23687164492864,
+            7.30178758577696, 17.23666888682254, 7.29826760007174,
+            17.23822295266038, 7.30015437019847, 17.23957011909292,
         ]
 
         temp_g = self.compute_wbgt()['Tg']
@@ -69,30 +70,41 @@ class TestBernard(unittest.TestCase):
 
     def test_factor_e(self):
 
-        speeds   = numpy.asarray(
+        speeds = numpy.asarray(
             [0.09, 0.1, 0.5, 0.99, 1.0, 1.1]
         )
         ref_vals = [
-            1.1, 1.0589254117941675, 0.014354692507258626, -0.0988883294140563, -0.1, -0.1,
+            1.1,
+            1.0589254117941675,
+            0.014354692507258626,
+            -0.0988883294140563,
+            -0.1,
+            -0.1,
         ]
- 
+
         test_vals = bernard.factor_e(speeds)
 
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=14)
 
     def test_factor_c(self):
-        
-        speeds    = numpy.asarray(
+
+        speeds = numpy.asarray(
             [0.029, 0.03, 1.5, 3.0, 3.1]
-        ) 
-        ref_vals  = [0.850, 0.8549213665756566, 0.972150296874842, 0.9929213665756567, 1.0]
+        )
+        ref_vals = [
+            0.850,
+            0.8549213665756566,
+            0.972150296874842,
+            0.9929213665756567,
+            1.0,
+        ]
         test_vals = bernard.factor_c(speeds)
 
         numpy.testing.assert_equal(test_vals, ref_vals)
 
     def test_psychrometric_wetbulb(self):
-        
-        ref_vals = [17.96148884743604, 27.140425028129574] 
+
+        ref_vals = [17.96148884743604, 27.140425028129574]
 
 #        test_vals = bernard.psychrometric_wetbulb(
 #            self.Tair.to('degC').magnitude,
@@ -105,7 +117,7 @@ class TestBernard(unittest.TestCase):
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=14)
 
     def test_globe_temp(self):
-        
+
         ref_vals = [
             43.373697999106, 47.251008278667, 40.871798055794, 46.480333391746,
             41.149121325362, 46.290998065833, 41.158800636094, 46.226155488287,
@@ -118,23 +130,23 @@ class TestBernard(unittest.TestCase):
     def test_natural_wetbulb(self):
 
         ref_vals = [
-            22.597361554457 , 30.1031770977963, 21.9718865686289,
-            29.910508376066 , 22.0412173860209, 29.8631745445878,
-            22.043637213704 , 29.8469639002014, 21.9875609602373,
+            22.597361554457, 30.1031770977963, 21.9718865686289,
+            29.910508376066, 22.0412173860209, 29.8631745445878,
+            22.043637213704, 29.8469639002014, 21.9875609602373,
             29.9719304110844, 22.0175832783571, 30.081581757146,
-        ] 
+        ]
 
         test_vals = self.compute_wbgt()['Tnwb'].magnitude
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=13)
 
     def test_wetbulb_globe(self):
-        
+
         ref_vals = [
-            26.9928926879412, 34.0224256241908, 26.054680209199 ,
-            33.7334225415954, 26.158676435287 , 33.6624217943781,
+            26.9928926879412, 34.0224256241908, 26.054680209199,
+            33.7334225415954, 26.158676435287, 33.6624217943781,
             26.1623061768116, 33.6381058277984, 26.0781917966116,
             33.8255555941229, 26.1232252737912, 33.9900326132153,
-        ] 
+        ]
 
         test_vals = self.compute_wbgt()['Twbg'].magnitude
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=13)

--- a/tests/test_dimiceli.py
+++ b/tests/test_dimiceli.py
@@ -1,5 +1,4 @@
 import unittest
-from itertools import starmap
 
 import pandas
 import numpy
@@ -7,47 +6,49 @@ from metpy.units import units
 
 from pywbgt import dimiceli
 
-def degMinSec2Frac( degree, minute, second ):
 
-  return degree + (minute + second/60.0)/60.0
+def degMinSec2Frac(degree, minute, second):
+
+    return degree + (minute + second / 60.0) / 60.0
+
 
 class TestDimiceli(unittest.TestCase):
 
-    def setUp( self ):
+    def setUp(self):
 
-        lats = ( 33, 43, 59)
+        lats = (33, 43, 59)
         lons = (-84, 22, 59)
 
-        self.dates   = pandas.date_range(
-            '20000101T16', 
-            '20010101T16', 
-            freq      = 'MS',
-            inclusive = 'left'
+        self.dates = pandas.date_range(
+            '20000101T16',
+            '20010101T16',
+            freq='MS',
+            inclusive='left'
         )
 
-        self.solar  = units.Quantity( [500.0,  805.0], 'watt/meter**2')
-        self.pres   = units.Quantity( [985.0, 1013.0], 'hPa')
-        self.Tair   = units.Quantity( [ 25.0,   35.0], 'degree_Celsius')
-        self.Tdew   = units.Quantity( [ 15.0,   25.0], 'degree_Celsius')
-        self.speed  = units.Quantity( [  1.0,    5.0], 'mile/hour')
-        self.zspeed = units.Quantity( 2.0, 'meters' )
-        self.lats   = numpy.full( self.solar.size, degMinSec2Frac(*lats) )
-        self.lons   = numpy.full( self.solar.size, degMinSec2Frac(*lons) )
+        self.solar = units.Quantity([500.0, 805.0], 'watt/meter**2')
+        self.pres = units.Quantity([985.0, 1013.0], 'hPa')
+        self.Tair = units.Quantity([25.0, 35.0], 'degree_Celsius')
+        self.Tdew = units.Quantity([15.0, 25.0], 'degree_Celsius')
+        self.speed = units.Quantity([1.0, 5.0], 'mile/hour')
+        self.zspeed = units.Quantity(2.0, 'meters')
+        self.lats = numpy.full(self.solar.size, degMinSec2Frac(*lats))
+        self.lons = numpy.full(self.solar.size, degMinSec2Frac(*lons))
 
     def compute_wbgt(self):
 
         return dimiceli.wetbulb_globe(
             self.dates,
-            numpy.resize(self.lats,  self.dates.size),
-            numpy.resize(self.lons,  self.dates.size),
+            numpy.resize(self.lats, self.dates.size),
+            numpy.resize(self.lons, self.dates.size),
             numpy.resize(self.solar, self.dates.size),
-            numpy.resize(self.pres,  self.dates.size),
-            numpy.resize(self.Tair,  self.dates.size),
-            numpy.resize(self.Tdew,  self.dates.size),
+            numpy.resize(self.pres, self.dates.size),
+            numpy.resize(self.Tair, self.dates.size),
+            numpy.resize(self.Tdew, self.dates.size),
             numpy.resize(self.speed, self.dates.size),
-            zspeed          = self.zspeed,
-            natural_wetbulb = 'malchaire',
-            min_speed       = dimiceli.DIMICELI_MIN_SPEED,
+            zspeed=self.zspeed,
+            natural_wetbulb='malchaire',
+            min_speed=dimiceli.DIMICELI_MIN_SPEED,
         )
 
     def test_conv_heat_flow_coeff(self):
@@ -59,7 +60,7 @@ class TestDimiceli(unittest.TestCase):
 
     def test_atmos_vapor_pres(self):
 
-        ref_vals  = [16.053150020118238, 29.254910801080698]
+        ref_vals = [16.053150020118238, 29.254910801080698]
         test_vals = dimiceli.atmospheric_vapor_pressure(
             self.Tair.to('degC').magnitude,
             self.Tdew.to('degC').magnitude,
@@ -67,10 +68,10 @@ class TestDimiceli(unittest.TestCase):
         )
 
         numpy.testing.assert_equal(test_vals, ref_vals)
-        
+
     def test_thermal_emiss(self):
 
-        ref_vals  = [0.8548516210648657, 0.9313755074245822]
+        ref_vals = [0.8548516210648657, 0.9313755074245822]
         test_vals = dimiceli.thermal_emissivity(
             self.Tair.to('degC').magnitude,
             self.Tdew.to('degC').magnitude,
@@ -82,24 +83,38 @@ class TestDimiceli(unittest.TestCase):
     def test_factor_b(self):
 
         ref_vals = [
-            5.804440926414478e+09, 7.580495185370829e+09, 7.253425926414478e+09,
-            7.016682845370829e+09, 8.764311926414478e+09, 8.065993905370829e+09,
-            8.826937926414478e+09, 7.643289210370829e+09, 8.386207926414478e+09,
-            6.381148627870829e+09, 6.773091926414478e+09, 7.929456245370829e+09,
+            5.804440926414478e+09,
+            7.580495185370829e+09,
+            7.253425926414478e+09,
+            7.016682845370829e+09,
+            8.764311926414478e+09,
+            8.065993905370829e+09,
+            8.826937926414478e+09,
+            7.643289210370829e+09,
+            8.386207926414478e+09,
+            6.381148627870829e+09,
+            6.773091926414478e+09,
+            7.929456245370829e+09,
         ]
- 
+
         solar, cosz, f_db = dimiceli.solar_parameters(
             self.dates,
             numpy.resize(self.lats, self.dates.size),
             numpy.resize(self.lons, self.dates.size),
-            numpy.resize(self.solar.to('watt/m**2').magnitude, self.dates.size),
+            numpy.resize(
+                self.solar.to('watt/m**2').magnitude,
+                self.dates.size,
+            ),
         )
 
         test_vals = dimiceli.factor_b(
             numpy.resize(self.Tair.to('degC').magnitude, self.dates.size),
             numpy.resize(self.Tdew.to('degC').magnitude, self.dates.size),
             numpy.resize(self.pres.to('hPa').magnitude, self.dates.size),
-            numpy.resize(self.solar.to('watt/m**2').magnitude, self.dates.size),
+            numpy.resize(
+                self.solar.to('watt/m**2').magnitude,
+                self.dates.size,
+            ),
             f_db,
             cosz,
         )
@@ -108,13 +123,13 @@ class TestDimiceli(unittest.TestCase):
 
     def test_factor_c(self):
 
-        ref_vals  = [435690588.0876065, 1077116913.6427102]
+        ref_vals = [435690588.0876065, 1077116913.6427102]
         ss, _ = dimiceli.adjust_speed_2m(
             self.speed,
-            zspeed    = self.zspeed,
-            min_speed = dimiceli.DIMICELI_MIN_SPEED,
+            zspeed=self.zspeed,
+            min_speed=dimiceli.DIMICELI_MIN_SPEED,
         )
- 
+
         test_vals = dimiceli.factor_c(
             ss.to('meter/hour').magnitude
         )
@@ -131,12 +146,12 @@ class TestDimiceli(unittest.TestCase):
 
     def test_speed(self):
 
-        ref_vals  = (
+        ref_vals = (
             numpy
             .resize(self.speed, self.dates.size)
             .to('meter per second')
         )
-        ref_vals  = numpy.clip(
+        ref_vals = numpy.clip(
             ref_vals,
             dimiceli.DIMICELI_MIN_SPEED,
             None,
@@ -156,8 +171,8 @@ class TestDimiceli(unittest.TestCase):
             38.31750513722974, 40.68555674157649, 41.64127240504196,
             41.51158271804979, 45.10703183815943, 42.48553616231467,
             45.25068705123203, 42.09318854558204, 44.2397145788166,
-            40.92169020316264, 40.53945394120878, 40.60748977555843, 
-        ] 
+            40.92169020316264, 40.53945394120878, 40.60748977555843,
+        ]
 
         test_vals = self.compute_wbgt()['Tg'].magnitude
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=14)
@@ -169,7 +184,7 @@ class TestDimiceli(unittest.TestCase):
             30.18095989953724, 26.51191285155729, 30.48006102924928,
             26.56178120930073, 30.35957106528275, 26.21083301991828,
             29.99980389187549, 24.92632745083094, 29.90331293185496,
-        ] 
+        ]
 
         test_vals = self.compute_wbgt()['Tnwb'].magnitude
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=14)
@@ -180,9 +195,8 @@ class TestDimiceli(unittest.TestCase):
             27.07200235017836, 32.58621245781237, 28.54442277339258,
             32.92898847328603, 30.07974536372199, 33.33314995293743,
             30.14338425675692, 33.17033745481433, 29.69552602970612,
-            32.68420076494537, 28.05632000382341, 32.55381700741015,            
-        ] 
+            32.68420076494537, 28.05632000382341, 32.55381700741015,
+        ]
 
         test_vals = self.compute_wbgt()['Twbg'].magnitude
         numpy.testing.assert_almost_equal(test_vals, ref_vals, decimal=14)
-        

--- a/tests/test_liljegren.py
+++ b/tests/test_liljegren.py
@@ -1,5 +1,4 @@
 import unittest
-from itertools import starmap
 
 import pandas
 import numpy
@@ -8,92 +7,97 @@ from metpy.units import units
 from pywbgt.liljegren import wetbulb_globe
 from pywbgt.solar import solar_parameters
 
-def degMinSec2Frac( degree, minute, second ):
 
-  return degree + (minute + second/60.0)/60.0
+def degMinSec2Frac(degree, minute, second):
 
-class TestSolarParams( unittest.TestCase ):
+    return degree + (minute + second / 60.0) / 60.0
 
-  def setUp( self ):
 
-    self.lats = ( 33, 43, 59)
-    self.lons = (-84, 22, 59)
+class TestSolarParams(unittest.TestCase):
 
-    self.dates   = pandas.date_range(
-      '20000101T16', 
-      '20010101T16', 
-      freq      = 'MS',
-      inclusive = 'left'
-    )
+    def setUp(self):
 
-    self.ref_COSZ = numpy.array(
-        [0.4793185, 0.5436525, 0.6659659, 0.7999277, 0.8850331, 0.9173484,
-         0.9125873, 0.8857645, 0.8315311, 0.7408516, 0.6174007, 0.5131738],         
-        dtype = numpy.float32,
-    )
+        self.lats = (33, 43, 59)
+        self.lons = (-84, 22, 59)
 
-  def test_cosz(self):
+        self.dates = pandas.date_range(
+            start='20000101T16',
+            end='20010101T16',
+            freq='MS',
+            inclusive='left',
+        )
 
-    lats = numpy.full( self.dates.size, degMinSec2Frac( *self.lats ) )
-    lons = numpy.full( self.dates.size, degMinSec2Frac( *self.lons ) )
+        self.ref_COSZ = numpy.array(
+            [0.4793185, 0.5436525, 0.6659659, 0.7999277, 0.8850331, 0.9173484,
+             0.9125873, 0.8857645, 0.8315311, 0.7408516, 0.6174007, 0.5131738],
+            dtype=numpy.float32,
+        )
 
-    solar = numpy.full( self.dates.size, 1000 )
+    def test_cosz(self):
 
-    res = solar_parameters(
-        self.dates, lats, lons,
-        solar, 
-    )
-    numpy.testing.assert_almost_equal( res[1], self.ref_COSZ )
-  
-class TestWBGT( unittest.TestCase ):
+        lats = numpy.full(self.dates.size, degMinSec2Frac(*self.lats))
+        lons = numpy.full(self.dates.size, degMinSec2Frac(*self.lons))
 
-  def setUp( self ):
+        solar = numpy.full(self.dates.size, 1000)
 
-    dates       = pandas.to_datetime( ['2000-06-01T16:00:00'] ) 
-    lats        = ( 33, 43, 59)  
-    lons        = (-84, 22, 59)
+        res = solar_parameters(
+            self.dates, lats, lons,
+            solar,
+        )
+        numpy.testing.assert_almost_equal(res[1], self.ref_COSZ)
 
-    self.solar  = units.Quantity( [500.0, 1000.0], 'watt/meter**2')
-    self.solar  = units.Quantity( [500.0,  805.0], 'watt/meter**2')
-    self.pres   = units.Quantity( [985.0, 1013.0], 'hPa')
-    self.Tair   = units.Quantity( [ 25.0,   35.0], 'degree_Celsius')
-    self.Tdew   = units.Quantity( [ 15.0,   25.0], 'degree_Celsius')
-    self.speed  = units.Quantity( [  1.0,    5.0], 'mile/hour')
-    self.zspeed = units.Quantity( 2.0, 'meters' )
-    self.lats   = numpy.full( self.solar.size, degMinSec2Frac(*lats) )
-    self.lons   = numpy.full( self.solar.size, degMinSec2Frac(*lons) )
 
-    self.res    = wetbulb_globe( 
-      dates.repeat( self.solar.size ), self.lats, self.lons,
-      self.solar,
-      self.pres,
-      self.Tair,
-      self.Tdew,
-      self.speed,
-      avg = 1.0,
-      zspeed = self.zspeed,
-      min_speed = units.Quantity(0.13, 'm/s'),
-     )
+class TestWBGT(unittest.TestCase):
 
-  def test_Tg(self):
-    
-    #Tg   = numpy.asarray([41.968254, 48.867577], dtype=numpy.float32) 
-    Tg   = numpy.asarray([41.97033, 48.868675], dtype=numpy.float32) 
-    numpy.testing.assert_almost_equal(Tg, self.res['Tg'].magnitude)
+    def setUp(self):
 
-  def test_Tpsy(self):
-    
-    Tpsy = [18.278467178, 27.251123428]
-    numpy.testing.assert_almost_equal(Tpsy, self.res['Tpsy'].magnitude)
+        dates = pandas.to_datetime(['2000-06-01T16:00:00'])
+        lats = (33, 43, 59)
+        lons = (-84, 22, 59)
 
-  def test_Tnwb(self):
+        # self.solar = units.Quantity([500.0, 1000.0], 'watt/meter**2')
+        self.solar = units.Quantity([500.0, 805.0], 'watt/meter**2')
+        self.pres = units.Quantity([985.0, 1013.0], 'hPa')
+        self.Tair = units.Quantity([25.0, 35.0], 'degree_Celsius')
+        self.Tdew = units.Quantity([15.0, 25.0], 'degree_Celsius')
+        self.speed = units.Quantity([1.0, 5.0], 'mile/hour')
+        self.zspeed = units.Quantity(2.0, 'meters')
+        self.lats = numpy.full(self.solar.size, degMinSec2Frac(*lats))
+        self.lons = numpy.full(self.solar.size, degMinSec2Frac(*lons))
 
-    #Tnwb = numpy.asarray([23.319757, 29.015223], dtype=numpy.float32)
-    Tnwb = numpy.asarray([23.320795, 29.01568], dtype=numpy.float32)
-    numpy.testing.assert_almost_equal(Tnwb, self.res['Tnwb'].magnitude)
+        self.res = wetbulb_globe(
+            dates.repeat(self.solar.size),
+            self.lats,
+            self.lons,
+            self.solar,
+            self.pres,
+            self.Tair,
+            self.Tdew,
+            self.speed,
+            avg=1.0,
+            zspeed=self.zspeed,
+            min_speed=units.Quantity(0.13, 'm/s'),
+        )
 
-  def test_Twbg(self):
+    def test_Tg(self):
 
-    #Twbg = numpy.asarray([27.21748, 33.58417], dtype=numpy.float32) 
-    Twbg = numpy.asarray([27.218622, 33.58471], dtype=numpy.float32) 
-    numpy.testing.assert_almost_equal(Twbg, self.res['Twbg'].magnitude)
+        # Tg   = numpy.asarray([41.968254, 48.867577], dtype=numpy.float32)
+        Tg = numpy.asarray([41.97033, 48.868675], dtype=numpy.float32)
+        numpy.testing.assert_almost_equal(Tg, self.res['Tg'].magnitude)
+
+    def test_Tpsy(self):
+
+        Tpsy = [18.278467178, 27.251123428]
+        numpy.testing.assert_almost_equal(Tpsy, self.res['Tpsy'].magnitude)
+
+    def test_Tnwb(self):
+
+        # Tnwb = numpy.asarray([23.319757, 29.015223], dtype=numpy.float32)
+        Tnwb = numpy.asarray([23.320795, 29.01568], dtype=numpy.float32)
+        numpy.testing.assert_almost_equal(Tnwb, self.res['Tnwb'].magnitude)
+
+    def test_Twbg(self):
+
+        # Twbg = numpy.asarray([27.21748, 33.58417], dtype=numpy.float32)
+        Twbg = numpy.asarray([27.218622, 33.58471], dtype=numpy.float32)
+        numpy.testing.assert_almost_equal(Twbg, self.res['Twbg'].magnitude)

--- a/tests/test_nd_array.py
+++ b/tests/test_nd_array.py
@@ -1,0 +1,104 @@
+import unittest
+
+import pandas
+import numpy as np
+import xarray as xr
+
+import pywbgt
+
+
+class TestNDArray(unittest.TestCase):
+    """
+    Test of multidimension/xarray support
+
+    """
+
+    def setUp(self):
+
+        dims = ('t', 'y', 'x')
+        dates = pandas.date_range(
+            start='2000-06-01T12',
+            end='2000-06-02T12',
+            freq='1D',
+        )
+        lats = np.asarray((33, 43, 59))
+        lons = np.asarray((-84, 22, 50, 120))
+
+        shape = (len(dates), len(lats), len(lons))
+
+        self.data = xr.Dataset(
+            data_vars=dict(
+                solar=(
+                    dims,
+                    np.random.random(shape) * 1000,
+                    {'units': 'watt/meter**2'},
+                ),
+                pres=(
+                    dims,
+                    np.random.random(shape) * 40 + 985,
+                    {'units': 'hPa'},
+                ),
+                temp_air=(
+                    dims,
+                    np.random.random(shape) * 10 + 25,
+                    {'units': 'degree_Celsius'},
+                ),
+                temp_dew=(
+                    dims,
+                    np.random.random(shape) * 10 + 15,
+                    {'units': 'degree_Celsius'},
+                ),
+                speed=(
+                    dims,
+                    np.random.random(shape) * 4 + 1,
+                    {'units': 'mile/hour'},
+                ),
+            ),
+            coords=dict(
+                t=(('t'), dates, {'axis': 'T'}),
+                y=(('y'), lats, {'axis': 'Y'}),
+                x=(('x'), lons, {'axis': 'X'}),
+            ),
+        )
+
+        self.new_dim = 'stacked'
+        self.ref_ds = self.data.metpy.quantify().stack({self.new_dim: dims})
+
+    def check_method(self, method):
+
+        ref = pywbgt.wbgt(
+            method,
+            self.ref_ds.t.data,
+            self.ref_ds.y.data,
+            self.ref_ds.x.data,
+            self.ref_ds.solar.data,
+            self.ref_ds.pres.data,
+            self.ref_ds.temp_air.data,
+            self.ref_ds.temp_dew.data,
+            self.ref_ds.speed.data,
+        )
+
+        ref = self.ref_ds.assign(
+            {
+                key: (self.new_dim, val)
+                for key, val in ref.items()
+                if hasattr(val, 'shape')
+            }
+        ).unstack().metpy.dequantify()
+
+        res = pywbgt.wbgt(method, self.data).metpy.dequantify()
+
+        for var in res.data_vars:
+            np.testing.assert_equal(res[var].values, ref[var].values)
+
+    def test_liljegren(self):
+        self.check_method('liljegren')
+
+    def test_dimiceli(self):
+        self.check_method('dimiceli')
+
+    def test_dimiceli_nws(self):
+        self.check_method('dimiceli_nws')
+
+    def test_bernard(self):
+        self.check_method('bernard')


### PR DESCRIPTION
Adds a new unit test for N-dimensional arrays and Xarray; simply runs code using original method of Quantities for reference values, then passes in Dataset and checks result from each are equal.

Lints the unittests.

Fixes issue in `min_speed` coordinate variable for Xarray where the `units` attribute was an `Units` object when should be a `str`.