### PR TITLE
Fixes install bug for solar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pywbgt"
-version     = "3.0.1"
+version     = "3.0.2"
 description = "Package for estimating wetbulb globe temperature using various algorithms"
 readme      = "README.md"
 authors     = [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ EXT_PSY_WETBULB = Extension(
     **EXTS_KWARGS,
 )
 
-EXT_PSY_WETBULB = Extension(
+EXT_SOLAR = Extension(
     f'{NAME}.solar',
     sources=[os.path.join('src', NAME, 'solar' + EXT)],
     **EXTS_KWARGS,
@@ -48,6 +48,7 @@ EXTENSIONS = [
     EXT_LILJEGREN,
     EXT_BERNARD,
     EXT_PSY_WETBULB,
+    EXT_SOLAR,
 ]
 
 if 'build_ext' in sys.argv:


### PR DESCRIPTION
When adding the solar cython model, I just overwrote the psy_wetbulb module with the solar module, This fixes the issue; pys wetbulb is now loaded along with solar