### PR TITLE
Updates for macOS and Linux Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-14 = Apple Silicon (arm64). Intel macOS (macos-13) was retired
-        # by GitHub in Dec 2025 and x86_64 macOS is sunset entirely in 2027, so
-        # Intel/older-macOS users install from the sdist instead.
-        os: [ubuntu-latest, windows-latest, macos-14]
+        # Linux x86_64 + native Linux arm64 (ubuntu-*-arm, free for public
+        # repos), Windows x86_64, and macOS arm64. Intel macOS (macos-13) was
+        # retired by GitHub in Dec 2025 and x86_64 macOS is sunset entirely in
+        # 2027, so Intel/older-macOS users install from the sdist instead.
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,20 +65,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 = Intel (x86_64), macos-14 = Apple Silicon (arm64):
-        # each runner builds wheels for its own native architecture.
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        # macos-14 = Apple Silicon (arm64). Intel macOS (macos-13) was retired
+        # by GitHub in Dec 2025 and x86_64 macOS is sunset entirely in 2027, so
+        # Intel/older-macOS users install from the sdist instead.
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          # Homebrew's libomp is built for the runner's macOS version, so the
-          # wheel's deployment target must match or delocate refuses to bundle
-          # it. Set it per Apple-Silicon (macos-14) / Intel (macos-13) runner.
-          # Ignored on Linux/Windows.
-          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '14.0' || matrix.os == 'macos-13' && '13.0' || '' }}
+          # Homebrew's libomp on macos-14 targets macOS 14.0, so the arm64
+          # wheel must declare the same minimum or delocate refuses to bundle
+          # it. Ignored on Linux/Windows.
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '14.0' || '' }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ where = ["src"]
 # -----------------------------------------------------------------------------
 # cibuildwheel: builds the binary wheels in CI (see .github/workflows).
 #   * Build CPython 3.10-3.12; skip PyPy and musl-based Linux.
-#   * Import-test each wheel so a broken build fails immediately.
 #   * OpenMP: Linux manylinux images ship GCC+libgomp and Windows MSVC has
 #     /openmp built in; only macOS needs libomp installed first.
 # -----------------------------------------------------------------------------
@@ -71,6 +70,13 @@ skip  = "pp* *-musllinux*"
 # where those dependencies install as prebuilt wheels.
 # Regenerate C from .pyx so published wheels always track the current sources.
 environment = { PYWBGT_CYTHONIZE = "1" }
+
+[tool.cibuildwheel.linux]
+# Default manylinux2014 ships GCC 10.2.1, but NumPy's meson build requires
+# GCC >= 10.3. manylinux_2_28 (AlmaLinux 8) ships GCC 12+ and current pip,
+# which resolves the too-old-compiler error. Requires glibc >= 2.28 at runtime
+# (RHEL/CentOS 8+, Ubuntu 18.10+); older systems install from the sdist.
+manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install libomp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,17 @@ skip  = "pp* *-musllinux*"
 environment = { PYWBGT_CYTHONIZE = "1" }
 
 [tool.cibuildwheel.linux]
+# "auto64" builds the runner's native 64-bit arch only: x86_64 on the Intel
+# runner, aarch64 on the ubuntu-*-arm runner. This excludes 32-bit i686, which
+# has no modern NumPy wheels and fails compiling NumPy from source.
+archs = "auto64"
 # Default manylinux2014 ships GCC 10.2.1, but NumPy's meson build requires
 # GCC >= 10.3. manylinux_2_28 (AlmaLinux 8) ships GCC 12+ and current pip,
-# which resolves the too-old-compiler error. Requires glibc >= 2.28 at runtime
-# (RHEL/CentOS 8+, Ubuntu 18.10+); older systems install from the sdist.
-manylinux-x86_64-image = "manylinux_2_28"
+# which resolves the too-old-compiler error, for both architectures. Requires
+# glibc >= 2.28 at runtime (RHEL/CentOS 8+, Ubuntu 18.10+); older systems
+# install from the sdist.
+manylinux-x86_64-image  = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install libomp"


### PR DESCRIPTION
Drops builds for retired macOS runner, drops 32-bit i686 support, adds arm64 support. 